### PR TITLE
Merge 1.1. changes

### DIFF
--- a/extalife/__init__.py
+++ b/extalife/__init__.py
@@ -384,7 +384,6 @@ class ExtaLifeChannel(Entity):
 
         Actions are currently hardcoded in platforms
         """
-        return True
         
         import time
 

--- a/extalife/__init__.py
+++ b/extalife/__init__.py
@@ -42,7 +42,7 @@ OPT_DEF_LIGHT = {
 }
 
 OPT_DEF_COVER = {
-    CONF_OPTIONS_COVER_INV_CONTROL: True,
+    CONF_OPTIONS_COVER_INV_CONTROL: False,
 }
 OPT_DEF_ALL = {
     CONF_OPTIONS_LIGHT: OPT_DEF_LIGHT,
@@ -58,7 +58,7 @@ OPTIONS_CONF_SCHEMA = {
                 vol.Optional(CONF_OPTIONS_LIGHT_ICONS_LIST, default=DEVICE_ICON_ARR_LIGHT): cv.ensure_list,
             },
             vol.Optional(CONF_OPTIONS_COVER, default=OPT_DEF_COVER): {
-                vol.Optional(CONF_OPTIONS_COVER_INV_CONTROL, default=False): cv.boolean,
+                vol.Optional(CONF_OPTIONS_COVER_INV_CONTROL, default=OPT_DEF_COVER[CONF_OPTIONS_COVER_INV_CONTROL]): cv.boolean,
             },
     }
 
@@ -80,12 +80,14 @@ CONFIG_SCHEMA=vol.Schema(
 
 def setup(hass: HomeAssistantType, base_config):
     """Set up Exta Life component."""
+    from pprint import pformat
     conf = base_config[DOMAIN]
     # _LOGGER.info("config dump %s", conf)
     controller= None
 
     hass.data[DOMAIN] = {}
     options = conf.get(CONF_OPTIONS)
+    _LOGGER.debug("options: %s", pformat(conf))
     hass.data[DOMAIN][CONF_OPTIONS] = options
     data = hass.data[DOMAIN][DATA_STATUS_POLLER] = StatusPoller(hass, conf)
 
@@ -128,7 +130,7 @@ def setup(hass: HomeAssistantType, base_config):
     data.update()
 
     # start notification listener for immediate entity status updates from controller
-    data.start_listener()
+    #data.start_listener()
 
     # register callback for periodic status update polling + device discovery
     async_track_time_interval(hass, data.update, timedelta(minutes=conf[CONF_POLL_INTERVAL]))
@@ -382,6 +384,8 @@ class ExtaLifeChannel(Entity):
 
         Actions are currently hardcoded in platforms
         """
+        return True
+        
         import time
 
         # wait for the previous TCP commands to finish before executing action

--- a/extalife/__init__.py
+++ b/extalife/__init__.py
@@ -383,8 +383,7 @@ class ExtaLifeChannel(Entity):
         Run controller command/action.
 
         Actions are currently hardcoded in platforms
-        """
-        
+        """ 
         import time
 
         # wait for the previous TCP commands to finish before executing action

--- a/extalife/__init__.py
+++ b/extalife/__init__.py
@@ -28,29 +28,39 @@ CONF_CONTROLLER_IP = 'controller_ip'
 CONF_USER = 'user'
 CONF_PASSWORD = 'password'
 CONF_POLL_INTERVAL = 'poll_interval'        # in minutes
-CONF_PLATFORM_CFG = 'platform_config'       # additional per-platform configuration
-CONF_PLATFORM_CFG_SWITCH = 'switch'         # additional switch configuration
-CONF_PLATFORM_CFG_LIGHT = 'light'           # additional light configuration
-CONF_PLATFORM_CFG_LIGHT_ICONS = 'light_icons'           # map switches as lights for these Exta Life icons
-CONF_PLATFORM_CFG_COVER = 'cover'           # additional cover configuration
-CONF_PLATFORM_CFG_COVER_INV_STATUS = 'inverted_status'           # cover works as in Exta Life app: open = 0, closed = 100. Causes problems in HA GUI with UP/DOWN buttons
+CONF_OPTIONS = 'options'       # additional per-platform configuration
+CONF_OPTIONS_SWITCH = 'switch'         # additional switch configuration
+CONF_OPTIONS_LIGHT = 'light'           # additional light configuration
+CONF_OPTIONS_LIGHT_ICONS_LIST = 'icons_list'           # map switches as lights for these Exta Life icons
+CONF_OPTIONS_COVER = 'cover'           # additional cover configuration
+CONF_OPTIONS_COVER_INV_CONTROL = 'inverted_control'           # cover works as in Exta Life app: open = 0, closed = 100. Causes problems in HA GUI with UP/DOWN buttons
 DEFAULT_POLL_INTERVAL = 5
 
+# config options defaults
+OPT_DEF_LIGHT = {
+    CONF_OPTIONS_LIGHT_ICONS_LIST: DEVICE_ICON_ARR_LIGHT,
+}
+
+OPT_DEF_COVER = {
+    CONF_OPTIONS_COVER_INV_CONTROL: True,
+}
+OPT_DEF_ALL = {
+    CONF_OPTIONS_LIGHT: OPT_DEF_LIGHT,
+    CONF_OPTIONS_COVER: OPT_DEF_COVER
+}
 # signals
 SIGNAL_DATA_UPDATED = f"{DOMAIN}_data_updated"
 SIGNAL_NOTIF_STATE_UPDATED = f"{DOMAIN}_notif_state_updated"
 
 # schema validations
-PLATFORM_CONF_SCHEMA = vol.Schema(
-    {
-            CONF_PLATFORM_CFG_LIGHT: {
-                vol.Optional(CONF_PLATFORM_CFG_LIGHT_ICONS, default=DEVICE_ICON_ARR_LIGHT): cv.ensure_list,
+OPTIONS_CONF_SCHEMA = {
+            vol.Optional(CONF_OPTIONS_LIGHT, default=OPT_DEF_LIGHT): {
+                vol.Optional(CONF_OPTIONS_LIGHT_ICONS_LIST, default=DEVICE_ICON_ARR_LIGHT): cv.ensure_list,
             },
-            CONF_PLATFORM_CFG_COVER: {
-                vol.Optional(CONF_PLATFORM_CFG_COVER_INV_STATUS, default=False): cv.boolean,
+            vol.Optional(CONF_OPTIONS_COVER, default=OPT_DEF_COVER): {
+                vol.Optional(CONF_OPTIONS_COVER_INV_CONTROL, default=False): cv.boolean,
             },
     }
-)
 
 # config schema for HA validations
 CONFIG_SCHEMA=vol.Schema(
@@ -61,7 +71,7 @@ CONFIG_SCHEMA=vol.Schema(
                 vol.Required(CONF_USER): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Optional(CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL): cv.positive_int,
-                # vol.Optional(CONF_PLATFORM_CFG): PLATFORM_CONF_SCHEMA,
+                vol.Optional(CONF_OPTIONS, default=OPT_DEF_ALL): OPTIONS_CONF_SCHEMA,
             }
         )
     },
@@ -75,6 +85,8 @@ def setup(hass: HomeAssistantType, base_config):
     controller= None
 
     hass.data[DOMAIN] = {}
+    options = conf.get(CONF_OPTIONS)
+    hass.data[DOMAIN][CONF_OPTIONS] = options
     data = hass.data[DOMAIN][DATA_STATUS_POLLER] = StatusPoller(hass, conf)
 
     controller_ip = conf[CONF_CONTROLLER_IP] if conf[CONF_CONTROLLER_IP] != '' else None
@@ -138,6 +150,8 @@ def discover_devices(hass: HomeAssistantType, hass_config):
     """
 
     component_configs = {}
+    options = hass.data[DOMAIN][CONF_OPTIONS]
+    light_icons = options.get(CONF_OPTIONS_LIGHT).get(CONF_OPTIONS_LIGHT_ICONS_LIST)
 
     # get data from the StatusPoller object stored in HA object data
     channels = hass.data[DOMAIN][DATA_STATUS_POLLER].channels  # -> list
@@ -159,7 +173,7 @@ def discover_devices(hass: HomeAssistantType, hass_config):
 
         if chn_type in DEVICE_ARR_ALL_SWITCH:
             icon = channel["data"]["icon"]
-            if icon in DEVICE_ICON_ARR_LIGHT:
+            if icon in light_icons:
                 component_name = 'light'
             else:
                 component_name = 'switch'

--- a/extalife/cover.py
+++ b/extalife/cover.py
@@ -32,6 +32,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ExtaLifeCover(ExtaLifeChannel, CoverDevice):
     """Representation of an ExtaLife Cover."""
 
+    # Exta Life extreme cover positions
+    POS_CLOSED = 100
+    POS_OPEN = 0
+
     @property
     def is_inverted_control(self):
         from . import (DOMAIN, CONF_OPTIONS, CONF_OPTIONS_COVER, CONF_OPTIONS_COVER_INV_CONTROL)
@@ -49,46 +53,59 @@ class ExtaLifeCover(ExtaLifeChannel, CoverDevice):
     @property
     def current_cover_position(self):
         """Return current position of cover. 0 is closed, 100 is open."""
-        # need to invert value for Exta Life as HA "thinks" in % of a shutter being open :(
-        # return 100 - self.channel_data.get("data").get("value")
+        
+        # HA GUI buttons meaning:
+        # ARROW UP   - open cover
+        # ARROW DOWN - close cover
+        # THIS CANNOT BE CHANGED AS IT'S HARDCODED IN HA GUI
+
         val = self.channel_data.get("value")
-        pos = val if self.is_inverted_control else 100-val
+        pos = val if self.is_inverted_control else 100-val       
+        
+        _LOGGER.debug("current_cover_position for cover: %s. Model: %s, returned to HA: %s", self.entity_id, val, pos)
         return pos        
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         data = self.channel_data
         pos = int(kwargs.get(ATTR_POSITION))
-        value = pos if self.is_inverted_control else 100-pos
+        value = pos if self.is_inverted_control else 100-pos        
 
+        _LOGGER.debug("set_cover_position for cover: %s. From HA: %s, model: %s", self.entity_id, pos, value)
         if self.action(ExtaLifeAPI.ACTN_SET_POS, value=value):
             data["value"] = value
             self.schedule_update_ha_state()
 
     @property
     def is_closed(self):
-        """Return if the cover is closed."""
+        """Return if the cover is closed (affects roller icon and entity status)."""
         position = self.channel_data.get("value")
         _LOGGER.debug("is_closed state: %s", position)
 
         if position is None:
             return None
-        pos = 1 if self.is_inverted_control else 100
+        pos = ExtaLifeCover.POS_CLOSED
+        _LOGGER.debug("is_closed for cover: %s. model: %s, returned to HA: %s", self.entity_id, position, position == pos)
         return position == pos
 
     def open_cover(self, **kwargs):
         """Open the cover."""
         data = self.channel_data
+        pos  = ExtaLifeCover.POS_OPEN
 
-        if self.action(ExtaLifeAPI.ACTN_OPEN):
-            data["value"] = 0 if self.is_inverted_control else 100
+        if self.action(ExtaLifeAPI.ACTN_SET_POS, value=pos):
+            data["value"] = pos
+            _LOGGER.debug("open_cover for cover: %s. model: %s", self.entity_id, pos)
             self.schedule_update_ha_state()
 
     def close_cover(self, **kwargs):
         """Close the cover."""
         data = self.channel_data
-        if self.action(ExtaLifeAPI.ACTN_CLOSE):
-            data["value"] = 100 if self.is_inverted_control else 0
+        pos  = ExtaLifeCover.POS_CLOSED
+        
+        if self.action(ExtaLifeAPI.ACTN_SET_POS, value=pos):
+            data["value"] = pos
+            _LOGGER.debug("close_cover for cover: %s. model: %s", self.entity_id, pos)
             self.schedule_update_ha_state()
 
     def stop_cover(self, **kwargs):

--- a/extalife/pyextalife.py
+++ b/extalife/pyextalife.py
@@ -1,4 +1,4 @@
-""" ExtaLife JSN API wrapper library. Enables device control, discovery and status fetching from EFC-01 controller """
+""" ExtaLife JSON API wrapper library. Enables device control, discovery and status fetching from EFC-01 controller """
 from __future__ import print_function
 
 import logging
@@ -50,6 +50,7 @@ DEVICE_ARR_ALL_SENSOR = [
 DEVICE_ICON_ARR_LIGHT = [
     15,
     13,
+    8,9,14,16,17,
 ]  # override device and type rules based on icon; force 'light' MQTT device for some icons, but only when device was detected preliminarly as switch; 28 =LED
 
 

--- a/extalife/pyextalife.py
+++ b/extalife/pyextalife.py
@@ -338,7 +338,13 @@ class TCPAdapter:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
         # Bind to the server address
-        sock.bind(server_address)
+        try:
+            sock.bind(server_address)
+        except (socket.error, OSError) as e:
+            sock.close()
+            sock = None
+            log.error("Could not connect to receive UDP multicast from EFC-01 on port %s", MCAST_PORT)
+            return False
         # Tell the operating system to add the socket to the multicast group
         # on all interfaces (join multicast group)
         group = socket.inet_aton(MCAST_GRP)
@@ -396,7 +402,7 @@ class TCPAdapter:
         """
         from datetime import datetime
 
-        SOCK_TIMEOUT = 5  # let it run maximum for 5 seconds
+        SOCK_TIMEOUT = 15  # let it run maximum for 15 seconds
 
         request = {"command": command, "data": data}
         cmd = self._json_to_tcp(request)


### PR DESCRIPTION
**Fixes:**
* handle error during controller discovery when unable to join multicast group
* increased default timeout for command execution from 5 to 15 seconds. Prevents setup failure in large installations where the controller needs a lot more time to read devices' status

**New features:**
* support for configuration options (extra entries in configuration.yaml) to add extra flexibility for end users and impact the integration behaviour. Options are per-platform. The following are supported
  - cover: inverted control - makes the cover position slider act as in the Exta Life app. 0 = cover retracted / closed, 100 = cover fully open (window fully covered). Drawback: HA open/close GUI buttons are grayed out incorrectly in extreme positions (0 & 100) as HA expects retracted = 100 not 0.
  - light: map more switch (ROP/ROM) icons as lights in HA: (8,9,14,16,17)

**Breaking changes:**
* Cover platform will now work according to Home Assistant abstraction model where position 100 means cover is fully retracted (window not covered). This is a breaking change as all scenes, scripts and automations, which use the cover position slider will need to be amended. New position should be calculated as: _new_position = 100 - old_position_.
Meaning of the up/down (open/close) GUI buttons remains the same. This new behavior may be overridden by setting `inverted_control: True` in integration options for platform `cover`
* By default more icons of a ROP/ROM device (switch) will influence the mapping of these devices as lights instead of switches. Your existing switches will become lights. All scenes, scripts, automations and GUI layout will need to be updated. This behaviour may be overrides as well by integration options by setting `icons_list` to 15 and 17 only for platform `light`.